### PR TITLE
feat: bring ntcore-react into repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@mui/icons-material": "6.4.2",
         "@mui/material": "6.4.2",
         "@tailwindcss/vite": "4.0.0",
-        "ntcore-react": "2.0.3",
         "ntcore-ts-client": "3.1.2",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -3489,36 +3488,6 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
-    "node_modules/ntcore-react": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ntcore-react/-/ntcore-react-2.0.3.tgz",
-      "integrity": "sha512-rGbrqRMWNJ6IJJdbwFzl/dIDFIYDh1Gl86vxZQAyZe4S7C+nhDthBc6bXRMdTj0kLgOcxhp4Pmi8kJi340QOfw==",
-      "dependencies": {
-        "ntcore-ts-client": "^2.0.0-beta.6",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/ntcore-react/node_modules/ntcore-ts-client": {
-      "version": "2.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/ntcore-ts-client/-/ntcore-ts-client-2.0.0-beta.6.tgz",
-      "integrity": "sha512-d4Uj5VGfnEadydiwF9lmoTizYuEozg/CssPcD8A0FvuhTzjXWZJcRUug67h/ZD3pG+FEJX7p5/bjjTigLSmsIw==",
-      "dependencies": {
-        "@msgpack/msgpack": "^2.8.0",
-        "isomorphic-ws": "^5.0.0",
-        "mock-socket": "9.3.1",
-        "tslib": "2.6.2",
-        "uuid": "^9.0.1",
-        "ws": "^8.16.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/ntcore-react/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
     "node_modules/ntcore-ts-client": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/ntcore-ts-client/-/ntcore-ts-client-3.1.2.tgz",
@@ -4261,18 +4230,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@mui/icons-material": "6.4.2",
     "@mui/material": "6.4.2",
     "@tailwindcss/vite": "4.0.0",
-    "ntcore-react": "2.0.3",
     "ntcore-ts-client": "3.1.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useNTState, useNTValue } from 'ntcore-react'
+import { useNTState, useNTValue } from '../../lib/ntcore-react'
 import { NetworkTablesTypeInfos } from 'ntcore-ts-client'
 import { type FC } from 'react'
 import { LevelButtonGroup, IntakeToggle, StateHistory, Hexagon, Timer} from './components'

--- a/src/components/Dashboard/components/LevelButtonGroup.tsx
+++ b/src/components/Dashboard/components/LevelButtonGroup.tsx
@@ -1,27 +1,30 @@
-import { useState, type FC } from 'react'
+import type { FC } from 'react'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import ToggleButton from '@mui/material/ToggleButton'
 import Typography from '@mui/material/Typography'
+import { useNTState } from '../../../lib/ntcore-react'
+import { NetworkTablesTypeInfos } from 'ntcore-ts-client'
 
-export type Level = 'l1' | 'l2' | 'l3' | 'l4'
+export type Level = 'L1' | 'L2' | 'L3' | 'L4'
 
 const LevelButtonGroup: FC = () => {
-  const [level, setLevel] = useState<Level>('l1')
+  const [level, setLevel] = useNTState<string>('SmartDashboard/Presets/UI/SelectedCORALLevel', NetworkTablesTypeInfos.kString, 'L1')
 
   return (
     <div className="flex flex-col gap-y-2 justify-start">
       <Typography variant="h3">Level</Typography>
+      <Typography variant="h3">Current Set Level (Robot): {level}</Typography>
       <ToggleButtonGroup
         orientation="vertical"
         value={level}
         exclusive
-        onChange={(_e, v) => setLevel(v)}
+        onChange={(_e, v) => setLevel(v, {id: 1})}
         className="w-fit"
       >
-        <ToggleButton value="l1">L1</ToggleButton>
-        <ToggleButton value="l2">L2</ToggleButton>
-        <ToggleButton value="l3">L3</ToggleButton>
-        <ToggleButton value="l4">L4</ToggleButton>
+        <ToggleButton value="L1">L1</ToggleButton>
+        <ToggleButton value="L2">L2</ToggleButton>
+        <ToggleButton value="L3">L3</ToggleButton>
+        <ToggleButton value="L4">L4</ToggleButton>
       </ToggleButtonGroup>
     </div>
   )

--- a/src/components/Dashboard/components/StateHistory.tsx
+++ b/src/components/Dashboard/components/StateHistory.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type FC } from 'react'
 import Typography from '@mui/material/Typography'
-import { useNTValue } from 'ntcore-react'
 import { NetworkTablesTypeInfos } from 'ntcore-ts-client'
+import { useNTValue } from '../../../lib/ntcore-react'
 
 export type Intake = 'left' | 'right'
 

--- a/src/lib/ntcore-react/NTContext.tsx
+++ b/src/lib/ntcore-react/NTContext.tsx
@@ -1,0 +1,11 @@
+// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
+// The packaged version of this was buggy so I tossed it in here
+
+import { createContext } from "react";
+import { NetworkTables } from "ntcore-ts-client";
+
+type NTContextType = NetworkTables | null;
+
+const NTContext = createContext<NTContextType>(null);
+
+export default NTContext;

--- a/src/lib/ntcore-react/NTProvider.tsx
+++ b/src/lib/ntcore-react/NTProvider.tsx
@@ -1,0 +1,80 @@
+// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
+// The packaged version of this was buggy so I tossed it in here
+
+import { useEffect, useState, useRef } from "react";
+import { NetworkTables } from "ntcore-ts-client";
+import NTContext from "./NTContext.tsx";
+
+type NTProviderProps = {
+    children?: React.ReactNode;
+    port?: number;
+    teamNumber?: number;
+    uri?: string;
+};
+
+/**
+ * Used to give the rest of the application access to the network tables connection. This component should be placed at the top of the component tree.
+ * Pass in either a uri or a team number to create a network tables connection. If a uri is provided, the connection will be created using that uri. If a team number is provided, the connection will be created using the team number. If a uri is provided, the team number will be ignored.
+ *
+ * @param uri The uri of the network tables server
+ * @param teamNumber The team number of the network tables server
+ * @param port The port of the network tables server. Defaults to 5810
+ * @returns
+ */
+export default function NTProvider({
+    children = null,
+    uri,
+    teamNumber,
+    port,
+}: NTProviderProps) {
+    const [ntConnection, setNtConnection] = useState<NetworkTables | null>(
+        null
+    );
+    const [
+        ntConnectionCreatedUsingTeamNumber,
+        setNtConnectionCreatedUsingTeamNumber,
+    ] = useState<boolean>(false);
+
+    const oldTeamNumber = useRef<number | undefined>();
+
+    useEffect(() => {
+        // Create a network tables connection if one doesn't exist
+        // Otherwise, reconnect using the uri, or throw an error if a team number is provided
+        if (ntConnection === null) {
+            if (uri) {
+                setNtConnection(NetworkTables.getInstanceByURI(uri, port));
+                setNtConnectionCreatedUsingTeamNumber(false);
+            } else if (teamNumber) {
+                setNtConnection(
+                    NetworkTables.getInstanceByTeam(teamNumber, port)
+                );
+                setNtConnectionCreatedUsingTeamNumber(true);
+                oldTeamNumber.current = teamNumber;
+            } else {
+                throw new Error(
+                    "Either a uri or a team number must be provided to create a network tables connection"
+                );
+            }
+        } else if (uri) {
+            ntConnection.changeURI(uri, port);
+            setNtConnectionCreatedUsingTeamNumber(false);
+        } else if (
+            teamNumber !== oldTeamNumber.current &&
+            ntConnectionCreatedUsingTeamNumber
+        ) {
+            throw new Error(
+                "There is currently no support for changing a team number after the connection has been created. Use a uri instead."
+            );
+        } else {
+            throw new Error(
+                "Either a uri or a team number must be provided to create a network tables connection"
+            );
+        }
+    }, [uri, teamNumber, port]);
+
+    return (
+        <NTContext.Provider value={ntConnection}>
+            {ntConnection ? children : null}
+        </NTContext.Provider>
+    );
+}

--- a/src/lib/ntcore-react/NTTopicTypes.ts
+++ b/src/lib/ntcore-react/NTTopicTypes.ts
@@ -1,0 +1,5 @@
+// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
+// The packaged version of this was buggy so I tossed it in here
+
+type NTTopicTypes = string | number | boolean | string[] | number[] | ArrayBuffer | boolean[] | number[];
+export default NTTopicTypes;

--- a/src/lib/ntcore-react/index.tsx
+++ b/src/lib/ntcore-react/index.tsx
@@ -1,0 +1,8 @@
+import NTContext from './NTContext'
+import NTProvider from './NTProvider'
+import type NTTopicTypes from './NTTopicTypes'
+import useNTConnected from './useNTConnected'
+import useNTState from './useNTState'
+import useNTValue from './useNTValue'
+
+export { NTContext, NTProvider, useNTConnected, useNTState, useNTValue, NTTopicTypes }

--- a/src/lib/ntcore-react/useNTConnected.tsx
+++ b/src/lib/ntcore-react/useNTConnected.tsx
@@ -1,0 +1,26 @@
+// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
+// The packaged version of this was buggy so I tossed it in here
+
+import { useContext, useEffect, useState } from "react";
+import NTContext from "./NTContext";
+
+const useNTConnected = () => {
+    const client = useContext(NTContext);
+    const [connected, setConnected] = useState(false);
+    useEffect(() => {
+        if (client) {
+            const cleanup = client.addRobotConnectionListener((connected) => {
+                setConnected(connected);
+            });
+            return () => {
+                if (cleanup) {
+                    cleanup();
+                }
+            };
+        }
+    }, [client]);
+
+    return connected;
+};
+
+export default useNTConnected;

--- a/src/lib/ntcore-react/useNTState.ts
+++ b/src/lib/ntcore-react/useNTState.ts
@@ -1,0 +1,75 @@
+// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
+// The packaged version of this was buggy so I tossed it in here
+
+import { NetworkTablesTopic, NetworkTablesTypeInfo } from "ntcore-ts-client";
+import { useContext, useEffect, useState } from "react";
+import NTContext from "./NTContext";
+import NTTopicTypes from "./NTTopicTypes";
+
+const useNTState = <T extends NTTopicTypes>(
+    key: string,
+    ntType: NetworkTablesTypeInfo,
+    defaultValue: T
+): [
+    T,
+    (
+        value: T,
+        publishProperties?: {
+            persistent?: boolean;
+            retained?: boolean;
+            id?: number;
+        }
+    ) => void
+] => {
+    const client = useContext(NTContext);
+    const [topic, setTopic] = useState<NetworkTablesTopic<T> | null>(null);
+    const [value, setValue] = useState<T>(defaultValue);
+
+    useEffect(() => {
+        if (client) {
+            const listener = (value: T | null) => {
+                setValue(value ?? defaultValue);
+            };
+            const clientTopic = client.createTopic(key, ntType, defaultValue);
+            const subscriptionUID = clientTopic.subscribe(listener);
+            setTopic(clientTopic);
+
+            return () => {
+                if (subscriptionUID && clientTopic) {
+                    clientTopic.unsubscribe(subscriptionUID);
+                }
+            };
+        } else {
+            throw new Error(
+                "No NTProvider found. Please wrap your application in an NTProvider"
+            );
+        }
+    }, [key, client]);
+
+    /**
+     * Set the value of the topic
+     *
+     * Will likely throw an error if multiple apps try to set the value at the same time
+     * @param value Value to set
+     * @param publishProperties Properties to pass to the publish method
+     */
+    const setNTValue = (
+        value: T,
+        publishProperties?: {
+            persistent?: boolean;
+            retained?: boolean;
+            id?: number;
+        }
+    ) => {
+        if (topic) {
+            topic.announce(publishProperties?.id ?? undefined!);
+            topic.publish(publishProperties);
+            topic.setValue(value);
+            setValue(value);
+        }
+    };
+
+    return [value, setNTValue];
+};
+
+export default useNTState;

--- a/src/lib/ntcore-react/useNTValue.ts
+++ b/src/lib/ntcore-react/useNTValue.ts
@@ -1,0 +1,40 @@
+// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
+// The packaged version of this was buggy so I tossed it in here
+
+import { NetworkTablesTypeInfo } from "ntcore-ts-client";
+import { useContext, useEffect, useState } from "react";
+import NTContext from "./NTContext";
+import NTTopicTypes from "./NTTopicTypes";
+
+const useNTValue = <T extends NTTopicTypes>(
+    key: string,
+    ntType: NetworkTablesTypeInfo,
+    defaultValue: T
+) => {
+    const client = useContext(NTContext);
+    const [value, setValue] = useState<T>(defaultValue);
+
+    useEffect(() => {
+        if (client) {
+            const listener = (value: T | null) => {
+                setValue(value ?? defaultValue);
+            };
+            const clientTopic = client.createTopic(key, ntType, defaultValue);
+            const subscriptionUID = clientTopic.subscribe(listener);
+
+            return () => {
+                if (subscriptionUID && clientTopic) {
+                    clientTopic.unsubscribe(subscriptionUID);
+                }
+            };
+        } else {
+            throw new Error(
+                "No NTProvider found. Please wrap your application in an NTProvider"
+            );
+        }
+    }, [key, client]);
+
+    return value;
+};
+
+export default useNTValue;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { NTProvider } from 'ntcore-react'
+import { NTProvider } from './lib/ntcore-react'
 import App from './components/App'
 import CssBaseline from '@mui/material/CssBaseline';
 


### PR DESCRIPTION
### Summary

Was doing some reading and found that folks were finding the ntcore-react library to be [buggy](https://github.com/Patribots4738/PatriDashboard/blob/d16ac071d77cf33e1c4880b7c82d83f7af2a096e/src/lib/ntcore-react/useNTValue.ts#L5), so they brought the core pieces into their repo.

After doing this I've found that the previous error from `useNTState()` is not throwing...although there is a new one.