### PR TITLE
fix: add puid to publish params to fix publishing issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-dom": "18.3.1",
         "react-use": "17.6.0",
         "save-dev": "0.0.1-security",
-        "tailwindcss": "4.0.0"
+        "tailwindcss": "4.0.0",
+        "uuid": "11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "9.17.0",
@@ -4230,6 +4231,18 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "18.3.1",
     "react-use": "17.6.0",
     "save-dev": "0.0.1-security",
-    "tailwindcss": "4.0.0"
+    "tailwindcss": "4.0.0",
+    "uuid": "11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "9.17.0",

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,10 +1,10 @@
-import { useNTConnected } from 'ntcore-react'
+import { useNTConnected } from '../../lib/ntcore-react'
 import type { FC } from 'react'
 import NotConnected from '../NotConnected'
 import Dashboard from '../Dashboard'
 
 const App: FC = () => {
-  const connected = true;// useNTConnected()
+  const connected = useNTConnected()
 
   return (
     <main className="h-[100vh] grid grid-cols-4 gap-6 mx-auto px-6 py-2 md:grid-cols-12 w-full">

--- a/src/components/Dashboard/components/LevelButtonGroup.tsx
+++ b/src/components/Dashboard/components/LevelButtonGroup.tsx
@@ -8,7 +8,11 @@ import { NetworkTablesTypeInfos } from 'ntcore-ts-client'
 export type Level = 'L1' | 'L2' | 'L3' | 'L4'
 
 const LevelButtonGroup: FC = () => {
-  const [level, setLevel] = useNTState<string>('SmartDashboard/Presets/UI/SelectedCORALLevel', NetworkTablesTypeInfos.kString, 'L1')
+  const [level, setLevel] = useNTState<string>(
+    'SmartDashboard/Presets/UI/SelectedCORALLevel',
+    NetworkTablesTypeInfos.kString,
+    'L1'
+  )
 
   return (
     <div className="flex flex-col gap-y-2 justify-start">
@@ -18,7 +22,7 @@ const LevelButtonGroup: FC = () => {
         orientation="vertical"
         value={level}
         exclusive
-        onChange={(_e, v) => setLevel(v, {id: 1})}
+        onChange={(_e, v) => setLevel(v)}
         className="w-fit"
       >
         <ToggleButton value="L1">L1</ToggleButton>

--- a/src/lib/ntcore-react/NTContext.tsx
+++ b/src/lib/ntcore-react/NTContext.tsx
@@ -1,11 +1,11 @@
 // https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
 // The packaged version of this was buggy so I tossed it in here
 
-import { createContext } from "react";
-import { NetworkTables } from "ntcore-ts-client";
+import { createContext } from 'react'
+import { NetworkTables } from 'ntcore-ts-client'
 
-type NTContextType = NetworkTables | null;
+type NTContextType = NetworkTables | null
 
-const NTContext = createContext<NTContextType>(null);
+const NTContext = createContext<NTContextType>(null)
 
-export default NTContext;
+export default NTContext

--- a/src/lib/ntcore-react/NTProvider.tsx
+++ b/src/lib/ntcore-react/NTProvider.tsx
@@ -1,16 +1,13 @@
-// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
-// The packaged version of this was buggy so I tossed it in here
-
-import { useEffect, useState, useRef } from "react";
-import { NetworkTables } from "ntcore-ts-client";
-import NTContext from "./NTContext.tsx";
+import { useEffect, useState, useRef } from 'react'
+import { NetworkTables } from 'ntcore-ts-client'
+import NTContext from './NTContext.tsx'
 
 type NTProviderProps = {
-    children?: React.ReactNode;
-    port?: number;
-    teamNumber?: number;
-    uri?: string;
-};
+  children?: React.ReactNode
+  port?: number
+  teamNumber?: number
+  uri?: string
+}
 
 /**
  * Used to give the rest of the application access to the network tables connection. This component should be placed at the top of the component tree.
@@ -21,60 +18,44 @@ type NTProviderProps = {
  * @param port The port of the network tables server. Defaults to 5810
  * @returns
  */
-export default function NTProvider({
-    children = null,
-    uri,
-    teamNumber,
-    port,
-}: NTProviderProps) {
-    const [ntConnection, setNtConnection] = useState<NetworkTables | null>(
-        null
-    );
-    const [
-        ntConnectionCreatedUsingTeamNumber,
-        setNtConnectionCreatedUsingTeamNumber,
-    ] = useState<boolean>(false);
+export default function NTProvider({ children = null, uri, teamNumber, port }: NTProviderProps) {
+  const [ntConnection, setNtConnection] = useState<NetworkTables | null>(null)
+  const [ntConnectionCreatedUsingTeamNumber, setNtConnectionCreatedUsingTeamNumber] =
+    useState<boolean>(false)
 
-    const oldTeamNumber = useRef<number | undefined>();
+  const oldTeamNumber = useRef<number | undefined>()
 
-    useEffect(() => {
-        // Create a network tables connection if one doesn't exist
-        // Otherwise, reconnect using the uri, or throw an error if a team number is provided
-        if (ntConnection === null) {
-            if (uri) {
-                setNtConnection(NetworkTables.getInstanceByURI(uri, port));
-                setNtConnectionCreatedUsingTeamNumber(false);
-            } else if (teamNumber) {
-                setNtConnection(
-                    NetworkTables.getInstanceByTeam(teamNumber, port)
-                );
-                setNtConnectionCreatedUsingTeamNumber(true);
-                oldTeamNumber.current = teamNumber;
-            } else {
-                throw new Error(
-                    "Either a uri or a team number must be provided to create a network tables connection"
-                );
-            }
-        } else if (uri) {
-            ntConnection.changeURI(uri, port);
-            setNtConnectionCreatedUsingTeamNumber(false);
-        } else if (
-            teamNumber !== oldTeamNumber.current &&
-            ntConnectionCreatedUsingTeamNumber
-        ) {
-            throw new Error(
-                "There is currently no support for changing a team number after the connection has been created. Use a uri instead."
-            );
-        } else {
-            throw new Error(
-                "Either a uri or a team number must be provided to create a network tables connection"
-            );
-        }
-    }, [uri, teamNumber, port]);
+  useEffect(() => {
+    // Create a network tables connection if one doesn't exist
+    // Otherwise, reconnect using the uri, or throw an error if a team number is provided
+    if (ntConnection === null) {
+      if (uri) {
+        setNtConnection(NetworkTables.getInstanceByURI(uri, port))
+        setNtConnectionCreatedUsingTeamNumber(false)
+      } else if (teamNumber) {
+        setNtConnection(NetworkTables.getInstanceByTeam(teamNumber, port))
+        setNtConnectionCreatedUsingTeamNumber(true)
+        oldTeamNumber.current = teamNumber
+      } else {
+        throw new Error(
+          'Either a uri or a team number must be provided to create a network tables connection'
+        )
+      }
+    } else if (uri) {
+      ntConnection.changeURI(uri, port)
+      setNtConnectionCreatedUsingTeamNumber(false)
+    } else if (teamNumber !== oldTeamNumber.current && ntConnectionCreatedUsingTeamNumber) {
+      throw new Error(
+        'There is currently no support for changing a team number after the connection has been created. Use a uri instead.'
+      )
+    } else {
+      throw new Error(
+        'Either a uri or a team number must be provided to create a network tables connection'
+      )
+    }
+  }, [uri, teamNumber, port])
 
-    return (
-        <NTContext.Provider value={ntConnection}>
-            {ntConnection ? children : null}
-        </NTContext.Provider>
-    );
+  return (
+    <NTContext.Provider value={ntConnection}>{ntConnection ? children : null}</NTContext.Provider>
+  )
 }

--- a/src/lib/ntcore-react/NTTopicTypes.ts
+++ b/src/lib/ntcore-react/NTTopicTypes.ts
@@ -1,5 +1,2 @@
-// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
-// The packaged version of this was buggy so I tossed it in here
-
 type NTTopicTypes = string | number | boolean | string[] | number[] | ArrayBuffer | boolean[] | number[];
 export default NTTopicTypes;

--- a/src/lib/ntcore-react/useNTConnected.tsx
+++ b/src/lib/ntcore-react/useNTConnected.tsx
@@ -1,26 +1,23 @@
-// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
-// The packaged version of this was buggy so I tossed it in here
-
-import { useContext, useEffect, useState } from "react";
-import NTContext from "./NTContext";
+import { useContext, useEffect, useState } from 'react'
+import NTContext from './NTContext'
 
 const useNTConnected = () => {
-    const client = useContext(NTContext);
-    const [connected, setConnected] = useState(false);
-    useEffect(() => {
-        if (client) {
-            const cleanup = client.addRobotConnectionListener((connected) => {
-                setConnected(connected);
-            });
-            return () => {
-                if (cleanup) {
-                    cleanup();
-                }
-            };
+  const client = useContext(NTContext)
+  const [connected, setConnected] = useState(false)
+  useEffect(() => {
+    if (client) {
+      const cleanup = client.addRobotConnectionListener((connected) => {
+        setConnected(connected)
+      })
+      return () => {
+        if (cleanup) {
+          cleanup()
         }
-    }, [client]);
+      }
+    }
+  }, [client])
 
-    return connected;
-};
+  return connected
+}
 
-export default useNTConnected;
+export default useNTConnected

--- a/src/lib/ntcore-react/useNTState.ts
+++ b/src/lib/ntcore-react/useNTState.ts
@@ -1,75 +1,82 @@
-// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
-// The packaged version of this was buggy so I tossed it in here
-
-import { NetworkTablesTopic, NetworkTablesTypeInfo } from "ntcore-ts-client";
-import { useContext, useEffect, useState } from "react";
-import NTContext from "./NTContext";
-import NTTopicTypes from "./NTTopicTypes";
+import { NetworkTablesTopic, type NetworkTablesTypeInfo } from 'ntcore-ts-client'
+import { useContext, useEffect, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+import NTContext from './NTContext'
+import NTTopicTypes from './NTTopicTypes'
 
 const useNTState = <T extends NTTopicTypes>(
-    key: string,
-    ntType: NetworkTablesTypeInfo,
-    defaultValue: T
+  key: string,
+  ntType: NetworkTablesTypeInfo,
+  defaultValue: T
 ): [
-    T,
-    (
-        value: T,
-        publishProperties?: {
-            persistent?: boolean;
-            retained?: boolean;
-            id?: number;
-        }
-    ) => void
+  T,
+  (
+    value: T,
+    publishProperties?: {
+      persistent?: boolean
+      retained?: boolean
+      id?: number
+    }
+  ) => void,
 ] => {
-    const client = useContext(NTContext);
-    const [topic, setTopic] = useState<NetworkTablesTopic<T> | null>(null);
-    const [value, setValue] = useState<T>(defaultValue);
+  const client = useContext(NTContext)
+  const [topic, setTopic] = useState<NetworkTablesTopic<T> | null>(null)
+  const [value, setValue] = useState<T>(defaultValue)
+  const [id] = useState<string>(uuidv4())
 
-    useEffect(() => {
-        if (client) {
-            const listener = (value: T | null) => {
-                setValue(value ?? defaultValue);
-            };
-            const clientTopic = client.createTopic(key, ntType, defaultValue);
-            const subscriptionUID = clientTopic.subscribe(listener);
-            setTopic(clientTopic);
+  useEffect(() => {
+    if (client) {
+      const listener = (value: T | null) => {
+        setValue(value ?? defaultValue)
+      }
+      const clientTopic = client.createTopic(key, ntType, defaultValue)
+      const subscriptionUID = clientTopic.subscribe(listener)
+      setTopic(clientTopic)
 
-            return () => {
-                if (subscriptionUID && clientTopic) {
-                    clientTopic.unsubscribe(subscriptionUID);
-                }
-            };
-        } else {
-            throw new Error(
-                "No NTProvider found. Please wrap your application in an NTProvider"
-            );
+      return () => {
+        if (subscriptionUID && clientTopic) {
+          clientTopic.unsubscribe(subscriptionUID)
         }
-    }, [key, client]);
+      }
+    } else {
+      throw new Error('No NTProvider found. Please wrap your application in an NTProvider')
+    }
+  }, [key, client])
 
-    /**
-     * Set the value of the topic
-     *
-     * Will likely throw an error if multiple apps try to set the value at the same time
-     * @param value Value to set
-     * @param publishProperties Properties to pass to the publish method
-     */
-    const setNTValue = (
-        value: T,
-        publishProperties?: {
-            persistent?: boolean;
-            retained?: boolean;
-            id?: number;
-        }
-    ) => {
-        if (topic) {
-            topic.announce(publishProperties?.id ?? undefined!);
-            topic.publish(publishProperties);
-            topic.setValue(value);
-            setValue(value);
-        }
-    };
+  /**
+   * Set the value of the topic
+   *
+   * Will likely throw an error if multiple apps try to set the value at the same time
+   * @param value Value to set
+   * @param publishProperties Properties to pass to the publish method
+   */
+  const setNTValue = async (
+    value: T,
+    publishProperties?: {
+      persistent?: boolean
+      retained?: boolean
+    }
+  ) => {
+    if (topic) {
+      topic.announce({
+        type: 'string',
+        name: key,
+        // eslint-disable-next-line
+        // @ts-ignore
+        id,
+        properties: {},
+        // eslint-disable-next-line
+        // @ts-ignore
+        pubuid: id,
+      })
 
-    return [value, setNTValue];
-};
+      await topic.publish(publishProperties)
+      topic.setValue(value)
+      setValue(value)
+    }
+  }
 
-export default useNTState;
+  return [value, setNTValue]
+}
+
+export default useNTState

--- a/src/lib/ntcore-react/useNTValue.ts
+++ b/src/lib/ntcore-react/useNTValue.ts
@@ -1,40 +1,35 @@
-// https://github.com/CrispyBacon1999/ntcore-react/tree/main/src/lib
-// The packaged version of this was buggy so I tossed it in here
-
-import { NetworkTablesTypeInfo } from "ntcore-ts-client";
-import { useContext, useEffect, useState } from "react";
-import NTContext from "./NTContext";
-import NTTopicTypes from "./NTTopicTypes";
+import type { NetworkTablesTypeInfo } from 'ntcore-ts-client'
+import { useContext, useEffect, useState } from 'react'
+import NTContext from './NTContext'
+import NTTopicTypes from './NTTopicTypes'
 
 const useNTValue = <T extends NTTopicTypes>(
-    key: string,
-    ntType: NetworkTablesTypeInfo,
-    defaultValue: T
+  key: string,
+  ntType: NetworkTablesTypeInfo,
+  defaultValue: T
 ) => {
-    const client = useContext(NTContext);
-    const [value, setValue] = useState<T>(defaultValue);
+  const client = useContext(NTContext)
+  const [value, setValue] = useState<T>(defaultValue)
 
-    useEffect(() => {
-        if (client) {
-            const listener = (value: T | null) => {
-                setValue(value ?? defaultValue);
-            };
-            const clientTopic = client.createTopic(key, ntType, defaultValue);
-            const subscriptionUID = clientTopic.subscribe(listener);
+  useEffect(() => {
+    if (client) {
+      const listener = (value: T | null) => {
+        setValue(value ?? defaultValue)
+      }
+      const clientTopic = client.createTopic(key, ntType, defaultValue)
+      const subscriptionUID = clientTopic.subscribe(listener)
 
-            return () => {
-                if (subscriptionUID && clientTopic) {
-                    clientTopic.unsubscribe(subscriptionUID);
-                }
-            };
-        } else {
-            throw new Error(
-                "No NTProvider found. Please wrap your application in an NTProvider"
-            );
+      return () => {
+        if (subscriptionUID && clientTopic) {
+          clientTopic.unsubscribe(subscriptionUID)
         }
-    }, [key, client]);
+      }
+    } else {
+      throw new Error('No NTProvider found. Please wrap your application in an NTProvider')
+    }
+  }, [key, client])
 
-    return value;
-};
+  return value
+}
 
-export default useNTValue;
+export default useNTValue


### PR DESCRIPTION
### Summary

After discovering that `this._published` controls if we can publish to a topic I dug into the `ntcore-ts-client` code a bit and found that we needed to pass a `puid` value to the `.annouce()` function so that `params.pubuid === this._pubuid`. Although `ts` says it takes a `number` for an `id` I'm passing a uuid for the time being - probably something we will need to investigate in the future.

[Source](https://github.com/cjlawson02/ntcore-ts-client/blob/main/packages/ntcore-ts-client/src/lib/pubsub/topic.ts#L118)

<img width="1511" alt="Screenshot 2025-02-07 at 5 25 15 PM" src="https://github.com/user-attachments/assets/78811b14-0af8-4ca2-bf9d-7dd16581b59f" />
